### PR TITLE
fix for versions before version 7.0

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -775,7 +775,8 @@ class Query {
 
     protected function get_casted_value($prop, $val) {
         if($this->hasModel) {
-            return ($this->model)::get_casted_value($prop, $val);
+            $model = $this->model;
+            return $model::get_casted_value($prop, $val);
         }
         return $val;
     }


### PR DESCRIPTION
For versions prior to version 7.0, the syntax ($ bar-> foo)::callable is not accepted.