### PR TITLE
Fix throwing exception Query.php

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -785,10 +785,10 @@ class Query {
     }
 
     protected function get_raw_results() {
-        return static::wpdb()->get_results($this->sql(), 'ARRAY_A');
+        return static::wpdb()->get_results($this->sql(), 'ARRAY_A') ?? [];
     }
 
     protected function get_raw_row() {
-        return static::wpdb()->get_row($this->sql(), 'ARRAY_A');
+        return static::wpdb()->get_row($this->sql(), 'ARRAY_A') ?? [];
     }
 }


### PR DESCRIPTION
Fix throwing exception in `get_casted_row:771` when `wpdb()->get_results` or `wpdb()->get_row` returns `null`